### PR TITLE
#10 Member 회원정보 수정기능 추가

### DIFF
--- a/src/main/java/com/letmeclean/global/aop/CurrentEmail.java
+++ b/src/main/java/com/letmeclean/global/aop/CurrentEmail.java
@@ -1,0 +1,11 @@
+package com.letmeclean.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentEmail {
+}

--- a/src/main/java/com/letmeclean/global/aop/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/letmeclean/global/aop/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,27 @@
+package com.letmeclean.global.aop.argumentresolver;
+
+import com.letmeclean.global.aop.CurrentEmail;
+import com.letmeclean.global.utils.SecurityUtil;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasCurrentEmailAnnotation = parameter.hasParameterAnnotation(CurrentEmail.class);
+        boolean hasStringType = String.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasCurrentEmailAnnotation && hasStringType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return SecurityUtil.getCurrentMemberEmail();
+    }
+}

--- a/src/main/java/com/letmeclean/global/config/WebConfig.java
+++ b/src/main/java/com/letmeclean/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.letmeclean.global.config;
+
+import com.letmeclean.global.aop.argumentresolver.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/letmeclean/global/exception/ErrorCode.java
+++ b/src/main/java/com/letmeclean/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     INVALID_TOKEN(BAD_REQUEST, "유효한 토큰이 아닙니다."),
     BAD_REQUEST_PAYMENT_READY(BAD_REQUEST, "이미 진행중인 결제가 존재합니다."),
     BAD_REQUEST_PAYMENT_APPROVE(BAD_REQUEST, "처리하고자 하는 결제 정보가 존재하지 않습니다."),
+    BAD_REQUEST_PREV_PASSWORD(BAD_REQUEST, "이전 비밀번호와 일치하지 않습니다."),
 
     /* 404 NOT_FOUND */
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 사용자 정보를 찾을 수 없습니다."),
@@ -43,6 +44,10 @@ public enum ErrorCode {
 
     public static AppException throwBadRequestPaymentApprove() {
         throw new AppException(BAD_REQUEST_PAYMENT_APPROVE);
+    }
+
+    public static AppException throwBadRequestPrevPassword() {
+        throw new AppException(BAD_REQUEST_PREV_PASSWORD);
     }
 
     /* 404 NOT_FOUND */

--- a/src/main/java/com/letmeclean/member/application/MemberController.java
+++ b/src/main/java/com/letmeclean/member/application/MemberController.java
@@ -1,11 +1,10 @@
 package com.letmeclean.member.application;
 
+import com.letmeclean.global.aop.CurrentEmail;
 import com.letmeclean.global.constants.ResponseConstants;
 import com.letmeclean.global.utils.SecurityUtil;
-import com.letmeclean.issuedticket.domain.IssuedTicket;
 import com.letmeclean.issuedticket.dto.response.IssuedTicketDetailResponse;
 import com.letmeclean.member.service.MemberService;
-import com.letmeclean.payment.domain.Payment;
 import com.letmeclean.payment.dto.response.PaymentDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -39,16 +38,27 @@ public class MemberController {
     }
 
     @GetMapping("/members/payments")
-    public ResponseEntity<List<PaymentDetailResponse>> getMemberOfPaymentList(Pageable pageable) {
-        String email = SecurityUtil.getCurrentMemberEmail();
+    public ResponseEntity<List<PaymentDetailResponse>> getMemberOfPaymentList(@CurrentEmail String email, Pageable pageable) {
         List<PaymentDetailResponse> payments = memberService.findPaymentList(email, pageable);
         return ResponseEntity.ok(payments);
     }
 
     @GetMapping("/members/issued-tickets")
-    public ResponseEntity<List<IssuedTicketDetailResponse>> getMemberOfIssuedTicketList(Pageable pageable) {
-        String email = SecurityUtil.getCurrentMemberEmail();
+    public ResponseEntity<List<IssuedTicketDetailResponse>> getMemberOfIssuedTicketList(@CurrentEmail String email, Pageable pageable) {
         List<IssuedTicketDetailResponse> issuedTickets = memberService.findIssuedTicketList(email, pageable);
         return ResponseEntity.ok(issuedTickets);
+    }
+
+    @PutMapping("/members/info")
+    public ResponseEntity<Void> editMemberInfo(@CurrentEmail String email, @RequestBody EditInfoRequestDto editInfoRequestDto) {
+        memberService.editMemberInfo(email, editInfoRequestDto);
+        return ResponseConstants.OK;
+    }
+
+    @PutMapping("/members/password")
+    public ResponseEntity<Void> changePassword(@CurrentEmail String email, @RequestBody EditPasswordRequestDto editPasswordRequestDto) {
+        memberService.editPassword(email, editPasswordRequestDto);
+
+        return ResponseConstants.OK;
     }
 }

--- a/src/main/java/com/letmeclean/member/domain/Member.java
+++ b/src/main/java/com/letmeclean/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.letmeclean.member.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.letmeclean.global.BaseTimeEntity;
+import com.letmeclean.global.exception.ErrorCode;
 import com.letmeclean.issuedticket.domain.IssuedTicket;
 import com.letmeclean.payment.domain.Payment;
 import lombok.AccessLevel;
@@ -63,6 +64,18 @@ public class Member extends BaseTimeEntity {
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<IssuedTicket> issuedTickets = new ArrayList<>();
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void changeTel(String tel) {
+        this.tel = tel;
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 
     public void addPayment(Payment payment) {
         payment.linkMember(this);

--- a/src/main/java/com/letmeclean/member/dto/MemberRequest.java
+++ b/src/main/java/com/letmeclean/member/dto/MemberRequest.java
@@ -13,10 +13,15 @@ public class MemberRequest {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class SignUpRequestDto {
 
+        @Email
         private String email;
+        @NotBlank
         private String password;
+        @NotBlank
         private String username;
+        @NotBlank
         private String nickname;
+        @NotBlank
         private String tel;
 
         @Builder
@@ -66,6 +71,35 @@ public class MemberRequest {
         @Builder
         public LogoutRequestDto(String accessToken) {
             this.accessToken = accessToken;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class EditInfoRequestDto {
+
+        @NotBlank
+        private String nickname;
+        @NotBlank
+        private String tel;
+
+        public EditInfoRequestDto(String nickname, String tel) {
+            this.nickname = nickname;
+            this.tel = tel;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class EditPasswordRequestDto {
+
+        private String prevPassword;
+        @NotBlank
+        private String newPassword;
+
+        public EditPasswordRequestDto(String prevPassword, String newPassword) {
+            this.prevPassword = prevPassword;
+            this.newPassword = newPassword;
         }
     }
 }

--- a/src/main/java/com/letmeclean/member/service/MemberService.java
+++ b/src/main/java/com/letmeclean/member/service/MemberService.java
@@ -1,13 +1,13 @@
 package com.letmeclean.member.service;
 
 import com.letmeclean.global.exception.ErrorCode;
-import com.letmeclean.issuedticket.domain.IssuedTicket;
 import com.letmeclean.issuedticket.domain.IssuedTicketRepository;
 import com.letmeclean.issuedticket.dto.response.IssuedTicketDetailResponse;
 import com.letmeclean.member.domain.Member;
 import com.letmeclean.member.domain.MemberRepository;
+import com.letmeclean.member.dto.MemberRequest.EditInfoRequestDto;
+import com.letmeclean.member.dto.MemberRequest.EditPasswordRequestDto;
 import com.letmeclean.member.dto.MemberRequest.SignUpRequestDto;
-import com.letmeclean.payment.domain.Payment;
 import com.letmeclean.payment.domain.PaymentRepository;
 import com.letmeclean.global.utils.MatcherUtil;
 import com.letmeclean.payment.dto.response.PaymentDetailResponse;
@@ -71,5 +71,26 @@ public class MemberService {
 
     public List<IssuedTicketDetailResponse> findIssuedTicketList(String email, Pageable pageable) {
         return issuedTicketRepository.findIssuedTicketsByEmail(email, pageable);
+    }
+
+    @Transactional
+    public void editMemberInfo(String email, EditInfoRequestDto editInfoRequestDto) {
+        Member member = findMember(email);
+        member.changeNickname(editInfoRequestDto.getNickname());
+        member.changeTel(editInfoRequestDto.getTel());
+    }
+
+    @Transactional
+    public void editPassword(String email, EditPasswordRequestDto editPasswordRequestDto) {
+        Member member = findMember(email);
+        String prevPassword = editPasswordRequestDto.getPrevPassword();
+        String newPassword = editPasswordRequestDto.getNewPassword();
+        String encodedPassword = passwordEncoder.encode(prevPassword);
+
+        if (passwordEncoder.matches(prevPassword, encodedPassword)) {
+            member.changePassword(passwordEncoder.encode(newPassword));
+        } else {
+            ErrorCode.throwBadRequestPrevPassword();
+        }
     }
 }

--- a/src/main/java/com/letmeclean/payment/application/PaymentController.java
+++ b/src/main/java/com/letmeclean/payment/application/PaymentController.java
@@ -1,5 +1,6 @@
 package com.letmeclean.payment.application;
 
+import com.letmeclean.global.aop.CurrentEmail;
 import com.letmeclean.payment.application.dto.PaymentReadyRequest;
 import com.letmeclean.payment.service.dto.PaymentApproveDto;
 import com.letmeclean.payment.service.dto.PaymentReadyDto;
@@ -16,15 +17,15 @@ public class PaymentController {
     private final PaymentApiService paymentApiService;
 
     @PostMapping("/ready")
-    public ResponseEntity<PaymentReadyDto> ready(@RequestBody PaymentReadyRequest request) {
-        PaymentReadyDto paymentReadyDto = paymentApiService.ready(request);
+    public ResponseEntity<PaymentReadyDto> ready(@CurrentEmail String email, @RequestBody PaymentReadyRequest request) {
+        PaymentReadyDto paymentReadyDto = paymentApiService.ready(email, request);
 
         return ResponseEntity.ok(paymentReadyDto);
     }
 
     @GetMapping("/approve")
-    public ResponseEntity<PaymentApproveDto> approve(@RequestParam("pg_token") String pgToken) {
-        PaymentApproveDto paymentApproveDto = paymentApiService.approve(pgToken);
+    public ResponseEntity<PaymentApproveDto> approve(@CurrentEmail String email, @RequestParam("pg_token") String pgToken) {
+        PaymentApproveDto paymentApproveDto = paymentApiService.approve(email, pgToken);
 
         return ResponseEntity.ok(paymentApproveDto);
     }

--- a/src/main/java/com/letmeclean/payment/service/KakaoPayApiService.java
+++ b/src/main/java/com/letmeclean/payment/service/KakaoPayApiService.java
@@ -41,9 +41,8 @@ public class KakaoPayApiService implements PaymentApiService {
 
     @Override
     @Transactional
-    public PaymentReadyDto ready(PaymentReadyRequest request) {
+    public PaymentReadyDto ready(String email, PaymentReadyRequest request) {
         String paymentNumber = UUID.randomUUID().toString();
-        String email = SecurityUtil.getCurrentMemberEmail();
         Ticket ticket = ticketRepository.findById(request.getTicketId())
                 .orElseThrow(() -> new RuntimeException());
 
@@ -79,8 +78,7 @@ public class KakaoPayApiService implements PaymentApiService {
 
     @Override
     @Transactional
-    public PaymentApproveDto approve(String pgToken) {
-        String email = SecurityUtil.getCurrentMemberEmail();
+    public PaymentApproveDto approve(String email, String pgToken) {
         PaymentCache paymentCache = paymentCacheRepository.findByEmail(email)
                 .orElseThrow(() -> ErrorCode.throwBadRequestPaymentApprove());
 

--- a/src/main/java/com/letmeclean/payment/service/interfaces/PaymentApiService.java
+++ b/src/main/java/com/letmeclean/payment/service/interfaces/PaymentApiService.java
@@ -6,7 +6,7 @@ import com.letmeclean.payment.service.dto.PaymentReadyDto;
 
 public interface PaymentApiService {
 
-    PaymentReadyDto ready(PaymentReadyRequest request);
+    PaymentReadyDto ready(String email, PaymentReadyRequest request);
 
-    PaymentApproveDto approve(String pgToken);
+    PaymentApproveDto approve(String email, String pgToken);
 }


### PR DESCRIPTION
## 개요
- [x] feature
- [ ] bug fix
- [ ] set up
- [ ] refactoring

## 작업사항
- Member가 회원정보를 수정할 수 있도록 기능 추가
    - 닉네임, 전화번호 수정 기능 추가
    - 비밀번호 수정기능 추가
- AOP 적용
    - 기존 SecurityUtil 에서 getCurrentMemberEmail로 가져오던 Email을  AOP 적용
    - ArgumentResolver를 추가해 @CurrentEmail로 파라미터 resolving
- 정보 수정기능에대한 테스트코드 작성