### PR TITLE
#12 Member에게 쿠폰 발급기능 추가

### DIFF
--- a/src/main/java/com/letmeclean/coupon/domain/Coupon.java
+++ b/src/main/java/com/letmeclean/coupon/domain/Coupon.java
@@ -2,6 +2,7 @@ package com.letmeclean.coupon.domain;
 
 import com.letmeclean.global.BaseTimeEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +34,7 @@ public class Coupon extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private CouponStatus couponStatus;
 
+    @Builder
     public Coupon(String name, Integer pointAmount, LocalDateTime expiredAt) {
         this.name = name;
         this.pointAmount = pointAmount;

--- a/src/main/java/com/letmeclean/coupon/dto/request/CouponRequest.java
+++ b/src/main/java/com/letmeclean/coupon/dto/request/CouponRequest.java
@@ -27,7 +27,11 @@ public class CouponRequest {
         private LocalDateTime expiredAt;
 
         public Coupon toEntity() {
-            return new Coupon(name, pointAmount, expiredAt);
+            return Coupon.builder()
+                    .name(name)
+                    .pointAmount(pointAmount)
+                    .expiredAt(expiredAt)
+                    .build();
         }
     }
 }

--- a/src/main/java/com/letmeclean/coupon/service/CouponService.java
+++ b/src/main/java/com/letmeclean/coupon/service/CouponService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class CouponService {
 
@@ -24,5 +25,10 @@ public class CouponService {
             ErrorCode.throwBadRequestCouponExpiredTime();
         }
         couponRepository.save(coupon);
+    }
+
+    public Coupon findCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> ErrorCode.throwCouponNotFound());
     }
 }

--- a/src/main/java/com/letmeclean/global/exception/ErrorCode.java
+++ b/src/main/java/com/letmeclean/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     /* 404 NOT_FOUND */
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 사용자 정보를 찾을 수 없습니다."),
     TICKET_NOT_FOUND(NOT_FOUND, "해당 티켓 정보를 찾을 수 없습니다."),
+    COUPON_NOT_FOUND(NOT_FOUND, "해당 쿠폰 정보를 찾을 수 없습니다."),
 
     /* 409 CONFLICT */
     DUPLICATE_EMAIL_CONFLICT(CONFLICT, "이미 해당 이메일 정보가 존재합니다."),
@@ -62,6 +63,10 @@ public enum ErrorCode {
 
     public static AppException throwTicketNotFound() {
         throw new AppException(TICKET_NOT_FOUND);
+    }
+
+    public static AppException throwCouponNotFound() {
+        throw new AppException(COUPON_NOT_FOUND);
     }
 
     /* 409 CONFLICT */

--- a/src/main/java/com/letmeclean/issuedcoupon/application/IssuedCouponController.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/application/IssuedCouponController.java
@@ -1,0 +1,29 @@
+package com.letmeclean.issuedcoupon.application;
+
+import com.letmeclean.global.aop.CurrentEmail;
+import com.letmeclean.global.constants.ResponseConstants;
+import com.letmeclean.issuedcoupon.domain.IssuedCoupon;
+import com.letmeclean.issuedcoupon.dto.request.IssuedCouponRequest;
+import com.letmeclean.issuedcoupon.service.CouponIssueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.letmeclean.issuedcoupon.dto.request.IssuedCouponRequest.*;
+
+@RequiredArgsConstructor
+@RestController
+public class IssuedCouponController {
+
+    private final CouponIssueService couponIssueService;
+
+    @PostMapping("/issue-coupon/{couponId}")
+    public ResponseEntity<Void> issueCouponToMember(@CurrentEmail String email, @PathVariable Long couponId) {
+        IssuedCouponRequestDto issuedCouponRequestDto = new IssuedCouponRequestDto(email, couponId);
+        couponIssueService.issueCouponToMember(issuedCouponRequestDto);
+
+        return ResponseConstants.OK;
+    }
+}

--- a/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCoupon.java
@@ -1,0 +1,44 @@
+package com.letmeclean.issuedcoupon.domain;
+
+import com.letmeclean.coupon.domain.Coupon;
+import com.letmeclean.global.BaseTimeEntity;
+import com.letmeclean.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class IssuedCoupon extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "issue_coupon_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private IssuedCouponStatus issuedCouponStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public void linkMember(Member member) {
+        this.member = member;
+    }
+
+    @Builder
+    public IssuedCoupon(IssuedCouponStatus issuedCouponStatus, Coupon coupon, Member member) {
+        this.issuedCouponStatus = issuedCouponStatus;
+        this.coupon = coupon;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCouponRepository.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCouponRepository.java
@@ -1,0 +1,6 @@
+package com.letmeclean.issuedcoupon.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
+}

--- a/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCouponStatus.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/domain/IssuedCouponStatus.java
@@ -1,0 +1,6 @@
+package com.letmeclean.issuedcoupon.domain;
+
+public enum IssuedCouponStatus {
+    NOT_USED,
+    USED
+}

--- a/src/main/java/com/letmeclean/issuedcoupon/dto/request/IssuedCouponRequest.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/dto/request/IssuedCouponRequest.java
@@ -1,0 +1,23 @@
+package com.letmeclean.issuedcoupon.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public class IssuedCouponRequest {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @Getter
+    public static class IssuedCouponRequestDto {
+
+        @NotBlank
+        private String email;
+        @NotNull
+        private Long couponId;
+    }
+}

--- a/src/main/java/com/letmeclean/issuedcoupon/service/CouponIssueService.java
+++ b/src/main/java/com/letmeclean/issuedcoupon/service/CouponIssueService.java
@@ -1,0 +1,38 @@
+package com.letmeclean.issuedcoupon.service;
+
+import com.letmeclean.coupon.domain.Coupon;
+import com.letmeclean.coupon.service.CouponService;
+import com.letmeclean.issuedcoupon.domain.IssuedCoupon;
+import com.letmeclean.issuedcoupon.domain.IssuedCouponRepository;
+import com.letmeclean.issuedcoupon.domain.IssuedCouponStatus;
+import com.letmeclean.issuedcoupon.dto.request.IssuedCouponRequest.IssuedCouponRequestDto;
+import com.letmeclean.member.domain.Member;
+import com.letmeclean.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CouponIssueService {
+
+    private final IssuedCouponRepository issuedCouponRepository;
+
+    private final MemberService memberService;
+    private final CouponService couponService;
+
+    @Transactional
+    public void issueCouponToMember(IssuedCouponRequestDto issuedCouponRequestDto) {
+        Coupon coupon = couponService.findCoupon(issuedCouponRequestDto.getCouponId());
+        Member member = memberService.findMember(issuedCouponRequestDto.getEmail());
+
+        IssuedCoupon issuedCoupon = IssuedCoupon.builder()
+                .issuedCouponStatus(IssuedCouponStatus.NOT_USED)
+                .coupon(coupon)
+                .member(member)
+                .build();
+        member.addIssuedCoupon(issuedCoupon);
+
+        issuedCouponRepository.save(issuedCoupon);
+    }
+}

--- a/src/main/java/com/letmeclean/issuedticket/service/TicketIssueService.java
+++ b/src/main/java/com/letmeclean/issuedticket/service/TicketIssueService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Service
-public class IssuedTicketService {
+public class TicketIssueService {
 
     private final IssuedTicketRepository issuedTicketRepository;
 

--- a/src/main/java/com/letmeclean/member/domain/Member.java
+++ b/src/main/java/com/letmeclean/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.letmeclean.member.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.letmeclean.global.BaseTimeEntity;
 import com.letmeclean.global.exception.ErrorCode;
+import com.letmeclean.issuedcoupon.domain.IssuedCoupon;
 import com.letmeclean.issuedticket.domain.IssuedTicket;
 import com.letmeclean.payment.domain.Payment;
 import lombok.AccessLevel;
@@ -57,13 +58,14 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
-    @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Payment> payments = new ArrayList<>();
 
-    @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<IssuedTicket> issuedTickets = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<IssuedCoupon> issuedCoupons = new ArrayList<>();
 
     public void changeNickname(String nickname) {
         this.nickname = nickname;
@@ -85,6 +87,11 @@ public class Member extends BaseTimeEntity {
     public void addIssuedTicket(IssuedTicket issuedTicket) {
         issuedTicket.linkMember(this);
         issuedTickets.add(issuedTicket);
+    }
+
+    public void addIssuedCoupon(IssuedCoupon issuedCoupon) {
+        issuedCoupon.linkMember(this);
+        issuedCoupons.add(issuedCoupon);
     }
 
     @Builder

--- a/src/main/java/com/letmeclean/ticket/service/TicketService.java
+++ b/src/main/java/com/letmeclean/ticket/service/TicketService.java
@@ -3,7 +3,7 @@ package com.letmeclean.ticket.service;
 import com.letmeclean.global.exception.ErrorCode;
 import com.letmeclean.issuedticket.domain.IssuedTicket;
 import com.letmeclean.issuedticket.domain.IssuedTicketStatus;
-import com.letmeclean.issuedticket.service.IssuedTicketService;
+import com.letmeclean.issuedticket.service.TicketIssueService;
 import com.letmeclean.member.domain.Member;
 import com.letmeclean.member.service.MemberService;
 import com.letmeclean.payment.domain.Payment;
@@ -25,7 +25,7 @@ import java.util.List;
 @Service
 public class TicketService {
 
-    private final IssuedTicketService issuedTicketService;
+    private final TicketIssueService ticketIssueService;
     private final MemberService memberService;
     private final PaymentService paymentService;
 
@@ -62,7 +62,7 @@ public class TicketService {
             member.addIssuedTicket(issuedTicket);
         }
 
-        issuedTicketService.issueTickets(issuedTickets);
+        ticketIssueService.issueTickets(issuedTickets);
 
         Payment payment = new Payment(
                 PaymentStatus.TICKET_PAY_COMPLETED,

--- a/src/test/java/com/letmeclean/issuedcoupon/service/CouponIssueServiceTest.java
+++ b/src/test/java/com/letmeclean/issuedcoupon/service/CouponIssueServiceTest.java
@@ -1,0 +1,82 @@
+package com.letmeclean.issuedcoupon.service;
+
+import com.letmeclean.coupon.domain.Coupon;
+import com.letmeclean.coupon.service.CouponService;
+import com.letmeclean.issuedcoupon.domain.IssuedCoupon;
+import com.letmeclean.issuedcoupon.domain.IssuedCouponRepository;
+import com.letmeclean.member.domain.Member;
+import com.letmeclean.member.service.MemberService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static com.letmeclean.issuedcoupon.dto.request.IssuedCouponRequest.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CouponIssueServiceTest {
+
+    @Mock
+    IssuedCouponRepository issuedCouponRepository;
+    @Mock
+    MemberService memberService;
+    @Mock
+    CouponService couponService;
+
+    @InjectMocks
+    CouponIssueService couponIssueService;
+
+    Member member;
+    Coupon coupon;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("23Yong@test.com")
+                .password("password")
+                .name("홍길동")
+                .nickname("ImGilDong")
+                .tel("010-1234-1234")
+                .build();
+        coupon = Coupon.builder()
+                .name("회원가입 쿠폰")
+                .pointAmount(10000)
+                .expiredAt(LocalDateTime.now().plusDays(14))
+                .build();
+    }
+
+    @DisplayName("회원이 쿠폰을 발급받으면")
+    @Nested
+    class IssueCouponTest {
+
+        @DisplayName("쿠폰 발급에 성공한다.")
+        @Test
+        void issueCouponSuccess() {
+            // given
+            String email = "23Yong@test.com";
+            Long couponId = 3L;
+            IssuedCouponRequestDto issuedCouponRequestDto = new IssuedCouponRequestDto(email, couponId);
+
+            when(memberService.findMember(email)).thenReturn(member);
+            when(couponService.findCoupon(couponId)).thenReturn(coupon);
+
+            // when
+            couponIssueService.issueCouponToMember(issuedCouponRequestDto);
+
+            // then
+            then(memberService).should().findMember(email);
+            then(couponService).should().findCoupon(couponId);
+            then(issuedCouponRepository).should().save(any(IssuedCoupon.class));
+            Assertions.assertAll(
+                    () -> assertThat(member.getIssuedCoupons()).hasSize(1),
+                    () -> assertThat(member.getIssuedCoupons().get(0).getMember()).isEqualTo(member)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- [x] feature
- [ ] bug fix
- [ ] set up
- [ ] refactoring

## 작업사항
- Member에게 쿠폰 발급 기능 추가
    - 멤버와 쿠폰을 바로 연결해주는 경우 다대다 관계가 형성
    - '1'이라는 식별자를 가진 쿠폰을 아이디가 '23Yong'이라는 사람과 '123'이라는 사람이 같이 쓰는 경우가 발생할 수 있는 문제 발생
    - IssuedCoupon 엔티티 생성
 - 쿠폰 발급에대한 테스트 코드 작성