### PR TITLE
카카오페이 API 테스트 코드 작성

### DIFF
--- a/src/main/java/com/letmeclean/dto/payment/api/dto/PaymentApproveDto.java
+++ b/src/main/java/com/letmeclean/dto/payment/api/dto/PaymentApproveDto.java
@@ -5,7 +5,7 @@ import com.letmeclean.dto.payment.api.response.KakaoPayApproveResponse;
 public record PaymentApproveDto(
         String email,
         String tid,
-        String movieTitle,
+        String ticketName,
         Integer quantity,
         Integer totalAmount
 ) {

--- a/src/main/java/com/letmeclean/global/config/JpaConfig.java
+++ b/src/main/java/com/letmeclean/global/config/JpaConfig.java
@@ -1,6 +1,5 @@
 package com.letmeclean.global.config;
 
-import com.letmeclean.global.security.userdetails.CustomUserDetails;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -21,7 +20,6 @@ public class JpaConfig {
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)
-                .map(CustomUserDetails.class::cast)
-                .map(CustomUserDetails::getUsername);
+                .map(String::valueOf);
     }
 }

--- a/src/main/java/com/letmeclean/global/config/SecurityConfig.java
+++ b/src/main/java/com/letmeclean/global/config/SecurityConfig.java
@@ -50,10 +50,10 @@ public class SecurityConfig {
                     .antMatchers("/api/payments/**").hasRole("MEMBER")
                     .antMatchers("/api/members/**").hasRole("MEMBER")
                     .antMatchers("/api/tickets").hasRole("ADMIN")
-                    .antMatchers("/coupons").hasRole("ADMIN")
-                    .anyRequest().authenticated()
-                .and()
-                    .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                    .anyRequest().authenticated();
+
+        http
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http
                 .logout(logout -> logout

--- a/src/main/java/com/letmeclean/model/member/Member.java
+++ b/src/main/java/com/letmeclean/model/member/Member.java
@@ -20,7 +20,7 @@ public class Member extends AuditingFields {
     @Column(nullable = false, unique = true, length = 50)
     private String email;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 200)
     private String password;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/letmeclean/service/payment/KakaoPayApiService.java
+++ b/src/main/java/com/letmeclean/service/payment/KakaoPayApiService.java
@@ -39,7 +39,7 @@ public class KakaoPayApiService implements PaymentApiService {
     private final TicketRepository ticketRepository;
     private final RedisPaymentCacheRepository paymentCacheRepository;
 
-    private final String paymentNumber = UUID.randomUUID().toString();
+    private String paymentNumber;
 
     @Override
     @Transactional
@@ -50,6 +50,7 @@ public class KakaoPayApiService implements PaymentApiService {
         Ticket ticket = ticketRepository.findById(request.ticketId())
                 .orElseThrow(() -> new LetMeCleanException(ErrorCode.TICKET_NOT_FOUND, String.format("%s 를(을) 찾을 수 없습니다.", request.ticketId())));
 
+        paymentNumber = UUID.randomUUID().toString();
         KakaoPayReadyResponse response = getKakaoPayReadyResponseByRequest(request, email, ticket);
 
         savePaymentInfoInCache(email, ticket, response);

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -1,1 +1,0 @@
-insert into member values (1, NOW(), '23Yong', '23Yong', NOW(), '23Yong@email.com', '23YongNickname', 'password', '010-1234-1234', 'JeongYong');

--- a/src/test/java/com/letmeclean/service/payment/service/KakaoPayApiServiceTest.java
+++ b/src/test/java/com/letmeclean/service/payment/service/KakaoPayApiServiceTest.java
@@ -1,0 +1,154 @@
+package com.letmeclean.service.payment.service;
+
+import com.letmeclean.api.KakaoPayClient;
+import com.letmeclean.api.KakaoPayProperties;
+import com.letmeclean.dto.payment.api.dto.PaymentApproveDto;
+import com.letmeclean.dto.payment.api.dto.PaymentReadyDto;
+import com.letmeclean.dto.payment.api.request.KakaoPayApproveRequest;
+import com.letmeclean.dto.payment.api.request.KakaoPayReadyRequest;
+import com.letmeclean.dto.payment.api.response.Amount;
+import com.letmeclean.dto.payment.api.response.CardInfo;
+import com.letmeclean.dto.payment.api.response.KakaoPayApproveResponse;
+import com.letmeclean.dto.payment.api.response.KakaoPayReadyResponse;
+import com.letmeclean.dto.payment.request.PaymentReadyRequest;
+import com.letmeclean.fixture.MemberEntityFixture;
+import com.letmeclean.fixture.TicketEntityFixture;
+import com.letmeclean.global.redis.paymentcache.PaymentCache;
+import com.letmeclean.global.redis.paymentcache.RedisPaymentCacheRepository;
+import com.letmeclean.model.member.Member;
+import com.letmeclean.model.member.MemberRepository;
+import com.letmeclean.model.ticket.Ticket;
+import com.letmeclean.model.ticket.TicketRepository;
+import com.letmeclean.service.TicketService;
+import com.letmeclean.service.payment.KakaoPayApiService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class KakaoPayApiServiceTest {
+
+    @Mock
+    KakaoPayClient kakaoPayClient;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    TicketRepository ticketRepository;
+    @Mock
+    RedisPaymentCacheRepository redisPaymentCacheRepository;
+    @Mock
+    KakaoPayProperties kakaoPayProperties;
+
+    @InjectMocks
+    KakaoPayApiService kakaoPayApiService;
+
+    @DisplayName("카카오페이 서버로 단건결제준비 요청을 보내면 올바른 응답을 받는다.")
+    @Test
+    void 카카오페이_결제준비() {
+        // given
+        PaymentReadyRequest paymentReadyRequest = new PaymentReadyRequest(1L, 4);
+        Member member = MemberEntityFixture.get();
+        Ticket ticket = TicketEntityFixture.get();
+
+        KakaoPayReadyResponse response = createReadyResponse();
+
+        given(kakaoPayProperties.getApprovalUrl()).willReturn("");
+        given(kakaoPayProperties.getCancelUrl()).willReturn("");
+        given(kakaoPayProperties.getFailUrl()).willReturn("");
+        given(kakaoPayProperties.getAuthorization()).willReturn("KAKAO");
+
+        given(memberRepository.existsByEmail(member.getEmail())).willReturn(true);
+        given(ticketRepository.findById(anyLong())).willReturn(Optional.of(ticket));
+        given(kakaoPayClient.ready(anyString(), any(KakaoPayReadyRequest.class))).willReturn(response);
+        given(redisPaymentCacheRepository.findByEmail(member.getEmail())).willReturn(Optional.empty());
+
+        // when
+        PaymentReadyDto actual = kakaoPayApiService.ready(member.getEmail(), paymentReadyRequest);
+
+        // then
+        assertThat(actual.tid()).isEqualTo(response.getTid());
+        assertThat(actual.nextRedirectAppUrl()).isEqualTo(response.getNextRedirectAppUrl());
+        assertThat(actual.nextRedirectMobileUrl()).isEqualTo(response.getNextRedirectMobileUrl());
+        assertThat(actual.nextRedirectPcUrl()).isEqualTo(response.getNextRedirectPcUrl());
+        assertThat(actual.androidAppScheme()).isEqualTo(response.getAndroidAppScheme());
+        assertThat(actual.iosAppScheme()).isEqualTo(response.getIosAppScheme());
+
+        then(memberRepository).should().existsByEmail(member.getEmail());
+        then(ticketRepository).should().findById(anyLong());
+        then(redisPaymentCacheRepository).should().findByEmail(member.getEmail());
+        then(redisPaymentCacheRepository).should().save(any(PaymentCache.class));
+    }
+
+    @DisplayName("카카오페이 서버로 단건결제승인 요청을 보내면 올바른 응답을 받는다.")
+    @Test
+    void 카카오페이_결제승인() {
+        // given
+        Member member = MemberEntityFixture.get();
+        Ticket ticket = TicketEntityFixture.get();
+        KakaoPayReadyResponse readyResponse = createReadyResponse();
+        PaymentCache paymentCache = PaymentCache.of(member.getEmail(), ticket.getName(), readyResponse.getTid(), 2L, "1111");
+        KakaoPayApproveResponse approveResponse = createApproveResponse();
+
+        given(redisPaymentCacheRepository.findByEmail(member.getEmail())).willReturn(Optional.of(paymentCache));
+        given(kakaoPayProperties.getAuthorization()).willReturn("KAKAO");
+        given(kakaoPayClient.approve(anyString(), any(KakaoPayApproveRequest.class))).willReturn(approveResponse);
+
+        // when
+        PaymentApproveDto actual = kakaoPayApiService.approve(member.getEmail(), "pgToken");
+
+        // then
+        then(redisPaymentCacheRepository).should().findByEmail(member.getEmail());
+        then(kakaoPayClient).should().approve(anyString(), any(KakaoPayApproveRequest.class));
+        then(redisPaymentCacheRepository).should().delete(paymentCache);
+
+        assertThat(actual.email()).isEqualTo(member.getEmail());
+        assertThat(actual.tid()).isEqualTo(approveResponse.getTid());
+        assertThat(actual.ticketName()).isEqualTo(approveResponse.getItemName());
+        assertThat(actual.quantity()).isEqualTo(3);
+    }
+
+    private KakaoPayReadyResponse createReadyResponse() {
+        return new KakaoPayReadyResponse(
+                "tid",
+                "nextRedirectUrl",
+                "nextRedirectUrl",
+                "nextRedirectUrl",
+                "appScheme",
+                "appScheme",
+                LocalDateTime.now()
+        );
+    }
+
+    private KakaoPayApproveResponse createApproveResponse() {
+        return new KakaoPayApproveResponse(
+                "aid",
+                "tid",
+                "cid",
+                "tid",
+                "partnerOrderId",
+                "partnerUserid",
+                "paymentMethodType",
+                new Amount(),
+                new CardInfo(),
+                "ticket",
+                "code",
+                3,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                "payload"
+        );
+    }
+}


### PR DESCRIPTION
- KakaoPayApiService 클래스에 대한 테스트코드 작성
- KakaoPayApiService 인스턴스는 하나인데, paymentNumber가 공유되고 있는 문제를 발견해 해당 부분 수정
- passwordEncoder를 통해 인코딩된 패스워드의 길이가 50자가 넘어 제약조건 수정
- anonymousUser의 경우 CustomUserDetails로 cast가 안되는 문제를 발견해 해당 부분 수정

This closes #48 